### PR TITLE
Section/6/page pre rendering and data fetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "18.2.0",
     "react-markdown": "^8.0.7",
     "react-syntax-highlighter": "^15.5.0",
+    "swr": "^2.1.5",
     "typescript": "5.0.4"
   }
 }

--- a/src/components/ui/error-alert.module.css
+++ b/src/components/ui/error-alert.module.css
@@ -10,3 +10,9 @@
   text-align: center;
   border-radius: 6px;
 }
+
+.center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/helpers/apiUtils.ts
+++ b/src/helpers/apiUtils.ts
@@ -18,3 +18,8 @@ export async function getFeaturedEvents() {
 
   return allEvents.filter((event) => event.isFeatured)
 }
+
+export async function getEventById(id: string | string[] | undefined) {
+  const allEvents = await getAllEvents()
+  return allEvents.find((event) => event.id === id)
+}

--- a/src/helpers/apiUtils.ts
+++ b/src/helpers/apiUtils.ts
@@ -1,4 +1,6 @@
-export const getAllEvents = async () => {
+import { Event } from '@/types/eventTypes'
+
+export const getAllEvents = async (): Promise<Event[]> => {
   const res = await fetch(
     'https://nextjs-course-project-4cea1-default-rtdb.firebaseio.com/events.json'
   )

--- a/src/helpers/apiUtils.ts
+++ b/src/helpers/apiUtils.ts
@@ -1,0 +1,20 @@
+export const getAllEvents = async () => {
+  const res = await fetch(
+    'https://nextjs-course-project-4cea1-default-rtdb.firebaseio.com/events.json'
+  )
+  const data = await res.json()
+  const events = []
+  for (const key in data) {
+    events.push({
+      id: key,
+      ...data[key],
+    })
+  }
+  return events
+}
+
+export async function getFeaturedEvents() {
+  const allEvents = await getAllEvents()
+
+  return allEvents.filter((event) => event.isFeatured)
+}

--- a/src/helpers/apiUtils.ts
+++ b/src/helpers/apiUtils.ts
@@ -25,3 +25,18 @@ export async function getEventById(id: string | string[] | undefined) {
   const allEvents = await getAllEvents()
   return allEvents.find((event) => event.id === id)
 }
+
+export async function getFilteredEvents(dateFilter: any) {
+  const { year, month } = dateFilter
+
+  const allEvents = await getAllEvents()
+
+  let filteredEvents = allEvents.filter((event) => {
+    const eventDate = new Date(event.date)
+    return (
+      eventDate.getFullYear() === year && eventDate.getMonth() === month - 1
+    )
+  })
+
+  return filteredEvents
+}

--- a/src/pages/events/[...slug].tsx
+++ b/src/pages/events/[...slug].tsx
@@ -2,29 +2,69 @@ import EventList from '@/components/events/EventList'
 import ResultsTitle from '@/components/events/ResultsTitle'
 import Button from '@/components/ui/Button'
 import ErrorAlert from '@/components/ui/ErrorAlert'
-import { GetServerSideProps, GetServerSidePropsContext } from 'next'
+// import { GetServerSideProps, GetServerSidePropsContext } from 'next'
 import { Event } from '@/types/eventTypes'
-import { getFilteredEvents } from '@/helpers/apiUtils'
+// import { getFilteredEvents } from '@/helpers/apiUtils'
 import classes from '@/components/ui/error-alert.module.css'
+import { useRouter } from 'next/router'
+import useSWR from 'swr'
+import { useEffect, useState } from 'react'
 /**
  * This page will only be rendered if there is more than one dynamic path param pass in
  * I.e. events/1/2
  * This is known as a catch all route
  * */
 
-interface FilteredEventsPageProps {
-  events: Event[]
-  date: {
-    year: number
-    month: number
+// interface FilteredEventsPageProps {
+//   events: Event[]
+//   date: {
+//     year: number
+//     month: number
+//   }
+//   hasError: boolean
+// }
+
+const FilteredEventsPage = (/* props: FilteredEventsPageProps */) => {
+  const router = useRouter()
+  const [allEvents, setAllEvents] = useState<Event[]>([])
+
+  const filteredData = router.query.slug as string[]
+
+  const { data, error } = useSWR(
+    'https://nextjs-course-project-4cea1-default-rtdb.firebaseio.com/events.json',
+    (url) => fetch(url).then((res) => res.json()),
+    { refreshInterval: 1000 }
+  )
+
+  useEffect(() => {
+    if (data) {
+      const events = []
+      for (const key in data) {
+        events.push({
+          id: key,
+          ...data[key],
+        })
+      }
+      setAllEvents(events)
+    }
+  }, [data])
+
+  if (!allEvents || !filteredData) {
+    return <p className="center">Loading...</p>
   }
-  hasError: boolean
-}
 
-const FilteredEventsPage = (props: FilteredEventsPageProps) => {
-  const { date, events, hasError } = props
+  const filteredYear = +filteredData[0]
+  const filteredMonth = +filteredData[1]
 
-  if (hasError) {
+  if (
+    isNaN(filteredYear) ||
+    isNaN(filteredMonth) ||
+    filteredYear > 2030 ||
+    filteredYear < 2021 ||
+    filteredMonth < 1 ||
+    filteredMonth > 12 ||
+    error
+  ) {
     return (
       <>
         <ErrorAlert>
@@ -37,7 +77,13 @@ const FilteredEventsPage = (props: FilteredEventsPageProps) => {
     )
   }
 
-  const filteredEvents = events
+  const filteredEvents = allEvents.filter((event) => {
+    const eventDate = new Date(event.date)
+    return (
+      eventDate.getFullYear() === filteredYear &&
+      eventDate.getMonth() === filteredMonth - 1
+    )
+  })
 
   if (!filteredEvents || filteredEvents.length === 0) {
     return (
@@ -54,61 +100,61 @@ const FilteredEventsPage = (props: FilteredEventsPageProps) => {
 
   return (
     <>
-      <ResultsTitle date={new Date(date.year, date.month - 1)} />
+      <ResultsTitle date={new Date(filteredYear, filteredMonth - 1)} />
       <EventList events={filteredEvents} />
     </>
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  const { params } = context
-  let filteredData: string[] | undefined
-  let filteredYear: number
-  let filteredMonth: number
+// export const getServerSideProps: GetServerSideProps = async (
+//   context: GetServerSidePropsContext
+// ) => {
+//   const { params } = context
+//   let filteredData: string[] | undefined
+//   let filteredYear: number
+//   let filteredMonth: number
 
-  if (!params) {
-    return {
-      props: {
-        hasError: true,
-      },
-    }
-  } else {
-    filteredData = params.slug as string[]
-    filteredYear = +filteredData[0]
-    filteredMonth = +filteredData[1]
-  }
+//   if (!params) {
+//     return {
+//       props: {
+//         hasError: true,
+//       },
+//     }
+//   } else {
+//     filteredData = params.slug as string[]
+//     filteredYear = +filteredData[0]
+//     filteredMonth = +filteredData[1]
+//   }
 
-  if (
-    isNaN(filteredYear) ||
-    isNaN(filteredMonth) ||
-    filteredYear > 2030 ||
-    filteredYear < 2021 ||
-    filteredMonth < 1 ||
-    filteredMonth > 12
-  ) {
-    return {
-      props: {
-        hasError: true,
-      },
-    }
-  }
+//   if (
+//     isNaN(filteredYear) ||
+//     isNaN(filteredMonth) ||
+//     filteredYear > 2030 ||
+//     filteredYear < 2021 ||
+//     filteredMonth < 1 ||
+//     filteredMonth > 12
+//   ) {
+//     return {
+//       props: {
+//         hasError: true,
+//       },
+//     }
+//   }
 
-  const filteredEvents = await getFilteredEvents({
-    year: filteredYear,
-    month: filteredMonth,
-  })
+//   const filteredEvents = await getFilteredEvents({
+//     year: filteredYear,
+//     month: filteredMonth,
+//   })
 
-  return {
-    props: {
-      events: filteredEvents,
-      date: {
-        year: filteredYear,
-        month: filteredMonth,
-      },
-    },
-  }
-}
+//   return {
+//     props: {
+//       events: filteredEvents,
+//       date: {
+//         year: filteredYear,
+//         month: filteredMonth,
+//       },
+//     },
+//   }
+// }
 
 export default FilteredEventsPage

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -3,12 +3,16 @@ import EventLogistics from '@/components/event-detail/EventLogistics'
 import EventSummary from '@/components/event-detail/EventSummary'
 import ErrorAlert from '@/components/ui/ErrorAlert'
 import { getEventById } from '@/dummy-data'
-import { useRouter } from 'next/router'
+import { getAllEvents } from '@/helpers/apiUtils'
+import { Event } from '@/types/eventTypes'
+import { GetStaticProps, GetStaticPropsContext, PreviewData } from 'next'
 
-const EventDetailPage = () => {
-  const router = useRouter()
-  const eventId = router.query.eventId
-  const event = getEventById(eventId)
+interface EventDetailPageProps {
+  event: Event
+}
+
+const EventDetailPage = (props: EventDetailPageProps) => {
+  const event = props.event
 
   if (!event) {
     return (
@@ -32,6 +36,34 @@ const EventDetailPage = () => {
       </EventContent>
     </>
   )
+}
+
+export const getStaticProps: GetStaticProps = async (
+  context: GetStaticPropsContext
+) => {
+  let eventId: string | undefined
+  let event: Event | undefined
+
+  if (context.params) {
+    eventId = context.params.eventId as string
+    event = getEventById(eventId)
+  }
+
+  return {
+    props: {
+      event,
+    },
+    revalidate: 30,
+  }
+}
+
+export async function getStaticPaths() {
+  const events = await getAllEvents()
+  const paths = events.map((event) => ({ params: { eventId: event.id } }))
+  return {
+    paths,
+    fallback: false,
+  }
 }
 
 export default EventDetailPage

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -1,11 +1,10 @@
 import EventContent from '@/components/event-detail/EventContent'
 import EventLogistics from '@/components/event-detail/EventLogistics'
 import EventSummary from '@/components/event-detail/EventSummary'
-import ErrorAlert from '@/components/ui/ErrorAlert'
 import { getEventById } from '@/dummy-data'
-import { getAllEvents } from '@/helpers/apiUtils'
+import { getFeaturedEvents } from '@/helpers/apiUtils'
 import { Event } from '@/types/eventTypes'
-import { GetStaticProps, GetStaticPropsContext, PreviewData } from 'next'
+import { GetStaticProps, GetStaticPropsContext } from 'next'
 
 interface EventDetailPageProps {
   event: Event
@@ -16,9 +15,9 @@ const EventDetailPage = (props: EventDetailPageProps) => {
 
   if (!event) {
     return (
-      <ErrorAlert>
-        <p>No event found!</p>
-      </ErrorAlert>
+      <div className="center">
+        <p>Loading...</p>
+      </div>
     )
   }
 
@@ -58,11 +57,11 @@ export const getStaticProps: GetStaticProps = async (
 }
 
 export async function getStaticPaths() {
-  const events = await getAllEvents()
+  const events = await getFeaturedEvents()
   const paths = events.map((event) => ({ params: { eventId: event.id } }))
   return {
     paths,
-    fallback: false,
+    fallback: 'blocking',
   }
 }
 

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -1,10 +1,14 @@
 import EventList from '@/components/events/EventList'
 import EventsSearch from '@/components/events/EventsSearch'
-import { getAllEvents } from '@/dummy-data'
+import { getAllEvents } from '@/helpers/apiUtils'
 import { useRouter } from 'next/router'
+import { Event } from '@/types/eventTypes'
 
-const EventsPage = () => {
-  const events = getAllEvents()
+interface EventsPageProps {
+  events: Event[]
+}
+
+const EventsPage = (props: EventsPageProps) => {
   const router = useRouter()
   const findEventsHandler = (year: string, month: string) => {
     const fullPath = `/events/${year}/${month}`
@@ -14,9 +18,20 @@ const EventsPage = () => {
   return (
     <div>
       <EventsSearch onSearch={findEventsHandler} />
-      <EventList events={events} />
+      <EventList events={props.events} />
     </div>
   )
+}
+
+export async function getStaticProps() {
+  const events = await getAllEvents()
+
+  return {
+    props: {
+      events,
+    },
+    revalidate: 60,
+  }
 }
 
 export default EventsPage

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,29 @@
-import { getAllEvents } from '@/dummy-data'
 import EventList from '@/components/events/EventList'
+import { getFeaturedEvents } from '@/helpers/apiUtils'
+import { Event } from '@/types/eventTypes'
 
-const HomePage = () => {
-  const featuredEvents = getAllEvents()
+interface HomePageProps {
+  events: Event[]
+}
 
+const HomePage = (props: HomePageProps) => {
+  const { events } = props
   return (
     <div>
-      <EventList events={featuredEvents} />
+      <EventList events={events} />
     </div>
   )
+}
+
+export async function getStaticProps() {
+  const featuredEvents = await getFeaturedEvents()
+
+  return {
+    props: {
+      events: featuredEvents,
+    },
+    revalidate: 1800,
+  }
 }
 
 export default HomePage

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import EventList from '@/components/events/EventList'
 import { getFeaturedEvents } from '@/helpers/apiUtils'
 import { Event } from '@/types/eventTypes'
+import { GetStaticProps } from 'next'
 
 interface HomePageProps {
   events: Event[]
@@ -15,7 +16,7 @@ const HomePage = (props: HomePageProps) => {
   )
 }
 
-export async function getStaticProps() {
+export const getStaticProps: GetStaticProps = async () => {
   const featuredEvents = await getFeaturedEvents()
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,6 +944,13 @@ styled-jsx@5.1.1:
   dependencies:
     client-only "0.0.1"
 
+swr@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.1.5.tgz#688effa719c03f6d35c66decbb0f8e79c7190399"
+  integrity sha512-/OhfZMcEpuz77KavXST5q6XE9nrOBOVcBLWjMT+oAE/kQHyE3PASrevXCtQDZ8aamntOfFkbVJp7Il9tNBQWrw==
+  dependencies:
+    use-sync-external-store "^1.2.0"
+
 tr46@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
@@ -1026,6 +1033,11 @@ unist-util-visit@^4.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^5.1.1"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 uvu@^0.5.0:
   version "0.5.6"


### PR DESCRIPTION
Section 6: Project Time: Page Pre-rendering and Data Fetching

- Continued building in the small events app from the previous section.
- Added Static Site Generation (SSG) to the home, events, and event detail, pages because we don't expect the data on these pages to change frequently and we want to serve up pages quickly that will get picked up by SEO.
-  Optimized these pages by adding Incremental Static Regeneration (ISR), through the revalidate prop, to pre-generate them after a certain number of seconds, and the fallback `blocking` prop for pre-generating the featured event detail pages that waits until the page is fully pre-generated before serving it to the client.
- Added Server Side Rendering (SSR) to the filtered events page because we want the client to receive an updated page on every request.
- Replaced SSR in the filtered events page with client side data fetching using useSWR as an alternative to the previous approach.